### PR TITLE
Nouvelle migration pour ajouter la colonne read à message. Dans chatr…

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -71,6 +71,25 @@
   margin-right: 3vh;
 }
 
+.honeycomb-mail-unread {
+  width: 6vh;
+  align-items: center;
+  flex: 1;
+  margin-right: 3vh;
+  color: rgb(255, 118, 118);
+}
+
+.message-non-lu{
+  color: white;
+}
+
+.container-unread{
+  position: relative;
+  right: 49px;
+  top: 21px;
+  font-size: smaller;
+}
+
 .dropdown-item {
   color: $orange;
 }

--- a/app/controllers/chatrooms_controller.rb
+++ b/app/controllers/chatrooms_controller.rb
@@ -10,6 +10,16 @@ class ChatroomsController < ApplicationController
     @user = current_user
     @review = Review.new
     @chatroom = Chatroom.find(params[:id])
+    #@messages_read = Message.where(chatroom_id: 114).where(user_id: @chatroom.helper_id)
+    if current_user.id == @chatroom.needer_id
+      @messages_read = Message.where(chatroom_id: @chatroom.id).where(user_id: @chatroom.helper_id)
+    else
+      @messages_read = Message.where(chatroom_id: @chatroom.id).where(user_id: @chatroom.needer_id)
+    end
+    @messages_read.each do |message|
+      message.read = true
+      message.save
+    end
     redirect_to :root unless current_user == @chatroom.helper || current_user == @chatroom.needer
     @message = Message.new
   end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -7,11 +7,37 @@
 </div>
     <div>
       <h1 class="humans">Humans</h1>
-    </div>
+    </div> 
     <div class="d-flex justify-content-end">
       <% if user_signed_in? %>
+          <% if current_user && (Chatroom.where(needer_id: current_user.id).exists? || Chatroom.where(helper_id: current_user.id).exists?) %>
+          <% @not_read_counting = 0 %>
+          <% Chatroom.where(needer_id: current_user.id).each do |chatroom|%>
+          <% if chatroom.messages.where.not(user_id: current_user.id).find_by(read: :false) %>
+          <% @not_read_counting += 1 %>
+          <% end %>
+          <% end %>
+          <% Chatroom.where(helper_id: current_user.id).each do |chatroom|%>
+          <% if chatroom.messages.where.not(user_id: current_user.id).find_by(read: :false) %>
+          <% @not_read_counting += 1 %>
+          <% end %>
+
+          <% end %>
+          <% #if @not_read_counting > 0 %>
+            <p><%= @not_read_counting %> message non-lus</p>
+          <%# end %>
+          <% end %>
+        <% if @not_read_counting != 0 %>
+        <%= link_to chatrooms_path, class: "mail-icon" do %>
+          <%= image_tag "https://res.cloudinary.com/dmei6ediu/image/upload/v1702937667/messagerie_message_itukm3.png", class: "honeycomb-mail-unread" %>
+        <% end %>
+        <div class = "container-unread">
+          <p class = "message-non-lu"><%= @not_read_counting %></p>
+        </div>
+        <% else %>
         <%= link_to chatrooms_path, class: "mail-icon" do %>
           <%= image_tag "https://res.cloudinary.com/durjq68ed/image/upload/v1702395857/messagerie-vide_umvmjq.png", class: "honeycomb-mail" %>
+        <% end %>
         <% end %>
 
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,5 +74,4 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
-  config.hosts << "0745-185-126-231-78.ngrok-free.app"
 end

--- a/db/migrate/20231218211304_add_read_to_messages.rb
+++ b/db/migrate/20231218211304_add_read_to_messages.rb
@@ -1,0 +1,5 @@
+class AddReadToMessages < ActiveRecord::Migration[7.1]
+  def change
+    add_column :messages, :read, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_18_091334) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_18_211304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,6 +61,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_18_091334) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "first_message", default: false
+    t.boolean "read", default: false
     t.index ["chatroom_id"], name: "index_messages_on_chatroom_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
   end


### PR DESCRIPTION
…oom#show, code de la logique pour que les messages de la personne passe en lu quand on ouvre la conversation. Dans navbar, code de la logique de calcul pour le nombre de message non-lu, ainsi qu'afficher une icone de messagerie différente quand messsage non-lu. CSS un peu bancal pour placer le nombre de message non-lu.